### PR TITLE
Correct "Bool" error in SpinalHDL v1.6.0+?

### DIFF
--- a/src/main/scala/mylib/MyTopLevel.scala
+++ b/src/main/scala/mylib/MyTopLevel.scala
@@ -26,9 +26,9 @@ import scala.util.Random
 //Hardware definition
 class MyTopLevel extends Component {
   val io = new Bundle {
-    val cond0 = in  Bool
-    val cond1 = in  Bool
-    val flag  = out Bool
+    val cond0 = in  Bool()
+    val cond1 = in  Bool()
+    val flag  = out Bool()
     val state = out UInt(8 bits)
   }
   val counter = Reg(UInt(8 bits)) init(0)


### PR DESCRIPTION
The written form of "Bool" is not supported in SpinalHDL versions equal to or greater than 1.6.0, so the template has been modified.